### PR TITLE
Variable allocations

### DIFF
--- a/make-it/EmMakefile
+++ b/make-it/EmMakefile
@@ -106,6 +106,8 @@ EM_EXPORTS = -s EXPORTED_FUNCTIONS="[\
     '_EggShell_REPL',\
     '_EggShell_ExecuteSlices',\
     '_EggShell_Delete',\
+    '_EggShell_AllocateData',\
+    '_EggShell_DeallocateData',\
     '_EggShell_FindValue',\
     '_EggShell_FindSubValue',\
     '_EggShell_ReadDouble',\

--- a/source/core/CEntryPoints.cpp
+++ b/source/core/CEntryPoints.cpp
@@ -150,6 +150,7 @@ VIREO_EXPORT EggShellResult EggShell_DeallocateData(TypeManagerRef tm, const Typ
     }
 
     NIError error = typeRef->ClearData(dataRef);
+    THREAD_TADM()->Free(dataRef);
     if (error != kNIError_Success) {
         return kEggShellResult_UnableToDeallocateData;
     }

--- a/source/core/CEntryPoints.cpp
+++ b/source/core/CEntryPoints.cpp
@@ -118,10 +118,14 @@ VIREO_EXPORT Int32 EggShell_PokeMemory(TypeManagerRef tm,
     }
 }
 //------------------------------------------------------------
-//! 
+//! Allocates enough memory to fit a new object of TypeRef
 VIREO_EXPORT EggShellResult EggShell_AllocateData(TypeManagerRef tm, const TypeRef typeRef, void** dataRefLocation)
 {
     TypeManagerScope scope(tm);
+    if (typeRef == nullptr || !typeRef->IsValid()) {
+        return kEggShellResult_InvalidTypeRef;
+    }
+
     *dataRefLocation = nullptr;
     Int32 topSize = typeRef->TopAQSize();
     void* pData = THREAD_TADM()->Malloc(topSize);
@@ -133,15 +137,23 @@ VIREO_EXPORT EggShellResult EggShell_AllocateData(TypeManagerRef tm, const TypeR
     return kEggShellResult_Success;
 }
 //------------------------------------------------------------
-//! 
-VIREO_EXPORT EggShellResult EggShell_DeallocateData(TypeManagerRef tm, const TypeRef typeRef, void* dataRefLocation)
+//! Deallocates data and frees up memory in dataRef described by typeRef
+VIREO_EXPORT EggShellResult EggShell_DeallocateData(TypeManagerRef tm, const TypeRef typeRef, void* dataRef)
 {
     TypeManagerScope scope(tm);
+    if (typeRef == nullptr || !typeRef->IsValid()) {
+        return kEggShellResult_InvalidTypeRef;
+    }
 
-    NIError error = typeRef->ClearData(dataRefLocation);
+    if (dataRef == nullptr) {
+        return kEggShellResult_NullDataPointer;
+    }
+
+    NIError error = typeRef->ClearData(dataRef);
     if (error != kNIError_Success) {
         return kEggShellResult_UnableToDeallocateData;
     }
+
     return kEggShellResult_Success;
 }
 //------------------------------------------------------------

--- a/source/core/CEntryPoints.cpp
+++ b/source/core/CEntryPoints.cpp
@@ -118,6 +118,33 @@ VIREO_EXPORT Int32 EggShell_PokeMemory(TypeManagerRef tm,
     }
 }
 //------------------------------------------------------------
+//! 
+VIREO_EXPORT EggShellResult EggShell_AllocateData(TypeManagerRef tm, const TypeRef typeRef, void** dataRefLocation)
+{
+    TypeManagerScope scope(tm);
+    *dataRefLocation = nullptr;
+    Int32 topSize = typeRef->TopAQSize();
+    void* pData = THREAD_TADM()->Malloc(topSize);
+    NIError error = typeRef->InitData(pData, (TypeRef)nullptr);
+    if (error != kNIError_Success) {
+        return kEggShellResult_UnableToAllocateData;
+    }
+    *dataRefLocation = pData;
+    return kEggShellResult_Success;
+}
+//------------------------------------------------------------
+//! 
+VIREO_EXPORT EggShellResult EggShell_DeallocateData(TypeManagerRef tm, const TypeRef typeRef, void* dataRefLocation)
+{
+    TypeManagerScope scope(tm);
+
+    NIError error = typeRef->ClearData(dataRefLocation);
+    if (error != kNIError_Success) {
+        return kEggShellResult_UnableToDeallocateData;
+    }
+    return kEggShellResult_Success;
+}
+//------------------------------------------------------------
 //! Get a reference to the type pointer and data for a symbol.
 VIREO_EXPORT EggShellResult EggShell_FindValue(TypeManagerRef tm, const char* viName, const char* eltName, TypeRef* typeRefLocation, void** dataRefLocation)
 {

--- a/source/core/CEntryPoints.cpp
+++ b/source/core/CEntryPoints.cpp
@@ -146,7 +146,7 @@ VIREO_EXPORT EggShellResult EggShell_DeallocateData(TypeManagerRef tm, const Typ
     }
 
     if (dataRef == nullptr) {
-        return kEggShellResult_NullDataPointer;
+        return kEggShellResult_InvalidDataPointer;
     }
 
     NIError error = typeRef->ClearData(dataRef);

--- a/source/include/CEntryPoints.h
+++ b/source/include/CEntryPoints.h
@@ -26,6 +26,7 @@ typedef enum {
     kEggShellResult_UnableToParseData = 7,
     kEggShellResult_UnableToAllocateData = 8,
     kEggShellResult_UnableToDeallocateData = 9,
+    kEggShellResult_NullDataPointer = 10,
 } EggShellResult;
 //------------------------------------------------------------
 //! TypeManager functions

--- a/source/include/CEntryPoints.h
+++ b/source/include/CEntryPoints.h
@@ -26,7 +26,7 @@ typedef enum {
     kEggShellResult_UnableToParseData = 7,
     kEggShellResult_UnableToAllocateData = 8,
     kEggShellResult_UnableToDeallocateData = 9,
-    kEggShellResult_NullDataPointer = 10,
+    kEggShellResult_InvalidDataPointer = 10,
 } EggShellResult;
 //------------------------------------------------------------
 //! TypeManager functions

--- a/source/include/CEntryPoints.h
+++ b/source/include/CEntryPoints.h
@@ -24,6 +24,8 @@ typedef enum {
     kEggShellResult_InvalidTypeRef = 5,
     kEggShellResult_MismatchedArrayRank = 6,
     kEggShellResult_UnableToParseData = 7,
+    kEggShellResult_UnableToAllocateData = 8,
+    kEggShellResult_UnableToDeallocateData = 9,
 } EggShellResult;
 //------------------------------------------------------------
 //! TypeManager functions
@@ -38,6 +40,8 @@ VIREO_EXPORT Int32 EggShell_PeekMemory(TypeManagerRef tm, const char* viName, co
                                        Int32 bufferSize, char* buffer);
 VIREO_EXPORT Int32 EggShell_PokeMemory(TypeManagerRef tm, const char* viName, const char* eltName,
                                        Int32 bufferSize, char* buffer);
+VIREO_EXPORT EggShellResult EggShell_AllocateData(TypeManagerRef tm, const TypeRef typeRef, void** dataRefLocation);
+VIREO_EXPORT EggShellResult EggShell_DeallocateData(TypeManagerRef tm, const TypeRef typeRef, void* dataRef);
 VIREO_EXPORT EggShellResult EggShell_FindValue(TypeManagerRef tm, const char* viName, const char* eltName, TypeRef* typeRefLocation, void** dataRefLocation);
 VIREO_EXPORT EggShellResult EggShell_FindSubValue(TypeManagerRef tm, const TypeRef type, void *start, const char* eltName,
         TypeRef* typeRefLocation, void** dataRefLocation);

--- a/source/io/module_eggShell.js
+++ b/source/io/module_eggShell.js
@@ -234,7 +234,7 @@
             if (eggShellResult !== EGGSHELL_RESULT.SUCCESS) {
                 throw new Error('A ValueRef could not be deallocated for the following reason: ' + eggShellResultEnum[eggShellResult] +
                     ' (error code: ' + eggShellResult + ')' +
-                    ' (typeRef: ' + valueRef.typeRef + ')' + 
+                    ' (typeRef: ' + valueRef.typeRef + ')' +
                     ' (dataRef: ' + valueRef.dataRef + ')');
             }
         };

--- a/source/io/module_eggShell.js
+++ b/source/io/module_eggShell.js
@@ -204,6 +204,29 @@
             });
         };
 
+        Module.eggShell.allocateData = publicAPI.eggShell.allocateData = function (valueRef) {
+            var stack = Module.stackSave();
+
+            var dataStackPointer = Module.stackAlloc(POINTER_SIZE);
+            var eggShellResult = Module._EggShell_AllocateData(Module.eggShell.v_userShell, valueRef.typeRef, dataStackPointer);
+            if (eggShellResult !== EGGSHELL_RESULT.SUCCESS) {
+                throw new Error();
+            }
+
+            var dataRef = Module.getValue(dataStackPointer, 'i32');
+            var allocatedValueRef = Module.eggShell.createValueRef(valueRef.typeRef, dataRef);
+
+            Module.stackRestore(stack);
+            return allocatedValueRef;
+        };
+
+        Module.eggShell.deallocateData = publicAPI.eggShell.deallocateData = function (valueRef) {
+            var eggShellResult = Module._EggShell_DeallocateData(Module.eggShell.v_userShell, valueRef.typeRef, valueRef.dataRef);
+            if (eggShellResult !== EGGSHELL_RESULT.SUCCESS) {
+                throw new Error();
+            }
+        };
+
         Module.eggShell.findValueRef = publicAPI.eggShell.findValueRef = function (vi, path) {
             var stack = Module.stackSave();
 

--- a/source/io/module_eggShell.js
+++ b/source/io/module_eggShell.js
@@ -84,7 +84,10 @@
             UNABLE_TO_CREATE_RETURN_BUFFER: 4,
             INVALID_TYPE_REF: 5,
             MISMATCHED_ARRAY_RANK: 6,
-            UNABLE_TO_PARSE_DATA: 7
+            UNABLE_TO_PARSE_DATA: 7,
+            UNABLE_TO_ALLOCATE_DATA: 8,
+            UNABLE_TO_DEALLOCATE_DATA: 9,
+            NULL_DATA_POINTER: 10
         };
         var eggShellResultEnum = {};
         eggShellResultEnum[EGGSHELL_RESULT.SUCCESS] = 'Success';
@@ -95,6 +98,9 @@
         eggShellResultEnum[EGGSHELL_RESULT.INVALID_TYPE_REF] = 'InvalidTypeRef';
         eggShellResultEnum[EGGSHELL_RESULT.MISMATCHED_ARRAY_RANK] = 'MismatchedArrayRank';
         eggShellResultEnum[EGGSHELL_RESULT.UNABLE_TO_PARSE_DATA] = 'UnableToParseData';
+        eggShellResultEnum[EGGSHELL_RESULT.UNABLE_TO_ALLOCATE_DATA] = 'UnableToAllocateData';
+        eggShellResultEnum[EGGSHELL_RESULT.UNABLE_TO_DEALLOCATE_DATA] = 'UnableToDeallocateData';
+        eggShellResultEnum[EGGSHELL_RESULT.NULL_DATA_POINTER] = 'NullDataPointer';
 
         // Keep in sync with NIError in DataTypes.h
         var niErrorEnum = {
@@ -210,7 +216,10 @@
             var dataStackPointer = Module.stackAlloc(POINTER_SIZE);
             var eggShellResult = Module._EggShell_AllocateData(Module.eggShell.v_userShell, valueRef.typeRef, dataStackPointer);
             if (eggShellResult !== EGGSHELL_RESULT.SUCCESS) {
-                throw new Error();
+                throw new Error('A new ValueRef could not be allocated for the following reason: ' + eggShellResultEnum[eggShellResult] +
+                    ' (error code: ' + eggShellResult + ')' +
+                    ' (typeRef: ' + valueRef.typeRef + ')' +
+                    ' (dataRef: ' + valueRef.dataRef + ')');
             }
 
             var dataRef = Module.getValue(dataStackPointer, 'i32');
@@ -223,7 +232,10 @@
         Module.eggShell.deallocateData = publicAPI.eggShell.deallocateData = function (valueRef) {
             var eggShellResult = Module._EggShell_DeallocateData(Module.eggShell.v_userShell, valueRef.typeRef, valueRef.dataRef);
             if (eggShellResult !== EGGSHELL_RESULT.SUCCESS) {
-                throw new Error();
+                throw new Error('A ValueRef could not be deallocated for the following reason: ' + eggShellResultEnum[eggShellResult] +
+                    ' (error code: ' + eggShellResult + ')' +
+                    ' (typeRef: ' + valueRef.typeRef + ')' + 
+                    ' (dataRef: ' + valueRef.dataRef + ')');
             }
         };
 

--- a/source/io/module_eggShell.js
+++ b/source/io/module_eggShell.js
@@ -87,7 +87,7 @@
             UNABLE_TO_PARSE_DATA: 7,
             UNABLE_TO_ALLOCATE_DATA: 8,
             UNABLE_TO_DEALLOCATE_DATA: 9,
-            NULL_DATA_POINTER: 10
+            INVALID_DATA_POINTER: 10
         };
         var eggShellResultEnum = {};
         eggShellResultEnum[EGGSHELL_RESULT.SUCCESS] = 'Success';
@@ -100,7 +100,7 @@
         eggShellResultEnum[EGGSHELL_RESULT.UNABLE_TO_PARSE_DATA] = 'UnableToParseData';
         eggShellResultEnum[EGGSHELL_RESULT.UNABLE_TO_ALLOCATE_DATA] = 'UnableToAllocateData';
         eggShellResultEnum[EGGSHELL_RESULT.UNABLE_TO_DEALLOCATE_DATA] = 'UnableToDeallocateData';
-        eggShellResultEnum[EGGSHELL_RESULT.NULL_DATA_POINTER] = 'NullDataPointer';
+        eggShellResultEnum[EGGSHELL_RESULT.INVALID_DATA_POINTER] = 'InvalidDataPointer';
 
         // Keep in sync with NIError in DataTypes.h
         var niErrorEnum = {

--- a/test-it/karma/fixtures/publicapi/AllocateTypes.via
+++ b/test-it/karma/fixtures/publicapi/AllocateTypes.via
@@ -1,0 +1,57 @@
+// Globals
+define(GlobalInt32 Int32)
+define(GlobalString String)
+define(GlobalErrorCluster ErrorCluster)
+define(GlobalClusterOfScalars c(
+    e(.Boolean bool)
+    e(.String string)
+    e(.Double double)
+    e(.Int32 int32)
+    e(.Int64 int64)
+    e(.ComplexDouble complex)
+    e(.Timestamp time)
+))
+
+define(GlobalArrayOfClusters a(c(
+    e(.Boolean bool)
+    e(.String string)
+    e(.Double double)
+    e(.Int32 int32)
+    e(.Int64 int64)
+    e(.ComplexDouble complex)
+    e(.Timestamp time)
+) *))
+
+define(GlobalClusterOfArrays c(
+    e(a(.Boolean *) booleans)
+    e(a(.String *) strings)
+    e(a(.Double *) doubles)
+    e(a(.Int32 *) int32s)
+    e(a(.Int64 *) int64s)
+    e(a(.UInt64 *) uint64s)
+    e(a(.ComplexDouble *) complexes)
+    e(a(.Timestamp *) times)
+))
+
+define(AllocateTypes dv(.VirtualInstrument (
+    Locals: c(
+        e(a(.Boolean *) booleans)
+        e(a(.String *) strings)
+        e(a(.Double *) doubles)
+        e(a(.Int32 *) int32s)
+        e(a(.Int64 *) int64s)
+        e(a(.UInt64 *) uint64s)
+        e(a(.ComplexDouble *) complexes)
+        e(a(.Timestamp *) times)
+
+        e(a(.Boolean 2 2) fixedBooleans)
+        e(.AnalogWaveform<.Double> wave_Double)
+        e(.NIPath nipath)
+        e(dv(Enum16 (zero one two three four) 3) enum16numbers)
+    )
+    clump (1
+    )
+)))
+
+enqueue(AllocateTypes)
+//Finished!! :D

--- a/test-it/karma/publicapi/AllocateTypes.Test.js
+++ b/test-it/karma/publicapi/AllocateTypes.Test.js
@@ -1,0 +1,255 @@
+describe('Vireo public API allows', function () {
+    'use strict';
+    // Reference aliases
+    var Vireo = window.NationalInstruments.Vireo.Vireo;
+    var vireoRunner = window.testHelpers.vireoRunner;
+    var fixtures = window.testHelpers.fixtures;
+
+    var vireo = new Vireo();
+
+    var publicApiAllocateTypesViaUrl = fixtures.convertToAbsoluteFromFixturesDir('publicapi/AllocateTypes.via');
+    var viName = 'AllocateTypes';
+
+    var expectValidValueRef = function (valueRef) {
+        expect(valueRef).toBeNonEmptyObject();
+        expect(valueRef.typeRef).toBeNumber();
+        expect(valueRef.typeRef).not.toBe(0);
+        expect(valueRef.dataRef).toBeNumber();
+        expect(valueRef.dataRef).not.toBe(0);
+    };
+
+    var allocateData = function (viName, path) {
+        return vireo.eggShell.allocateData(vireo.eggShell.findValueRef(viName, path));
+    };
+
+    var writeValue = function (valueRef, value) {
+        vireo.eggShell.writeJSON(valueRef, JSON.stringify(value));
+    };
+
+    var readValue = function (valueRef) {
+        return JSON.parse(vireo.eggShell.readJSON(valueRef));
+    };
+
+    var allocateTest = function (viName, path, value) {
+        var dataValueRef = allocateData(viName, path);
+        expectValidValueRef(dataValueRef);
+        writeValue(dataValueRef, value);
+        expect(readValue(dataValueRef)).toEqual(value);
+        vireo.eggShell.deallocateData(dataValueRef);
+    };
+
+    beforeAll(function (done) {
+        fixtures.preloadAbsoluteUrls([
+            publicApiAllocateTypesViaUrl
+        ], done);
+    });
+
+    beforeAll(function () {
+        vireoRunner.rebootAndLoadVia(vireo, publicApiAllocateTypesViaUrl);
+    });
+
+    var tryAllocate = function (valueRef) {
+        return function () {
+            vireo.eggShell.allocateData(valueRef);
+        };
+    };
+
+    var tryDeallocate = function (valueRef) {
+        return function () {
+            vireo.eggShell.deallocateData(valueRef);
+        };
+    };
+
+    describe('error handling', function () {
+        describe('for allocateData throws', function () {
+            it('when typeRef is invalid', function () {
+                var invalidValueRef = {
+                    typeRef: 0,
+                    dataRef: 1234
+                };
+
+                expect(tryAllocate(invalidValueRef)).toThrowError(/InvalidTypeRef/);
+            });
+        });
+
+        describe('for deallocateData throws', function () {
+            it('when typeRef is invalid', function () {
+                var invalidValueRef = {
+                    typeRef: 1234,
+                    dataRef: 1234
+                };
+
+                expect(tryDeallocate(invalidValueRef)).toThrowError(/InvalidTypeRef/);
+            });
+
+            it('when dataRef is null', function () {
+                var validValueRef = vireo.eggShell.findValueRef(viName, 'times');
+                var invalidValueRef = {
+                    typeRef: validValueRef.typeRef,
+                    dataRef: 0
+                };
+
+                expect(tryDeallocate(invalidValueRef)).toThrowError(/NullDataPointer/);
+            });
+        });
+    });
+
+    describe('allocation of new variables from', function () {
+        it('global variables', function () {
+            allocateTest('GlobalInt32', '', 1234);
+            allocateTest('GlobalString', '', 'Hola Mundo!');
+            allocateTest('GlobalErrorCluster', '', {
+                status: true,
+                code: 12345,
+                source: 'This is an error'
+            });
+            allocateTest('GlobalClusterOfScalars', '', {
+                bool: true,
+                string: 'Testing... Attention please.',
+                double: 2.7182,
+                int32: 1234,
+                int64: '9876543210',
+                complex: {
+                    real: 5.045,
+                    imaginary: -5.67
+                },
+                time: {
+                    seconds: '3564057536',
+                    fraction: '7811758927381448193'
+                }
+            });
+            allocateTest('GlobalArrayOfClusters', '', [
+                {
+                    bool: true,
+                    string: 'Look again at that dot.',
+                    double: 123.45,
+                    int32: 456,
+                    int64: '7890123456',
+                    complex: {
+                        real: -3.14,
+                        imaginary: 6.28
+                    },
+                    time: {
+                        seconds: '3564057542',
+                        fraction: '16691056759750171331'
+                    }
+                },
+                {
+                    bool: false,
+                    string: 'That\'s here. That\'s home. That\'s us.',
+                    double: -123.45,
+                    int32: -5678,
+                    int64: '-1234567890',
+                    complex: {
+                        real: 3.14,
+                        imaginary: -6.28
+                    },
+                    time: {
+                        seconds: '3564059871',
+                        fraction: '7811758927381448217'
+                    }
+                }
+            ]);
+            allocateTest('GlobalClusterOfArrays', '', {
+                booleans: [true, false, true],
+                strings: ['On', 'it', ' everyone', 'you,', 'love'],
+                doubles: [1.2, 3.4, 5.6, 7.89, 1234.5678],
+                int32s: [-1000, -10, 42, 9876543, 123],
+                int64s: [
+                    '-8989',
+                    '9090',
+                    '36028797018963968',
+                    '-72057594037927936'
+                ],
+                uint64s: [
+                    '9223372041149743104',
+                    '0',
+                    '9223376434901286912'
+                ],
+                complexes: [
+                    {
+                        real: 0,
+                        imaginary: 0
+                    }, {
+                        real: 10,
+                        imaginary: -10
+                    }, {
+                        real: 5.045,
+                        imaginary: -5.67
+                    }
+                ],
+                times: [
+                    {
+                        seconds: '3564057536',
+                        fraction: '7811758927381448193'
+                    }, {
+                        seconds: '3564057542',
+                        fraction: '16691056759750171331'
+                    }
+                ]
+            });
+        });
+
+        it('local variables in a VI', function () {
+            allocateTest(viName, 'booleans', [true, false, true, false]);
+            allocateTest(viName, 'strings', [
+                'everyone you know',
+                'everyone you ever heard of',
+                'every human being who ever was',
+                'lived out their lives'
+            ]);
+            allocateTest(viName, 'doubles', [1.2, 3.4, 5.6, 7.89, 1234.5678]);
+            allocateTest(viName, 'int32s', [-1000, -10, 42, 9876543, 123]);
+            allocateTest(viName, 'int64s', [
+                '-8989',
+                '9090',
+                '36028797018963968',
+                '-72057594037927936'
+            ]);
+            allocateTest(viName, 'uint64s', [
+                '9223372041149743104',
+                '0',
+                '9223376434901286912'
+            ]);
+            allocateTest(viName, 'complexes', [
+                {
+                    real: 0,
+                    imaginary: 0
+                }, {
+                    real: 10,
+                    imaginary: -10
+                }, {
+                    real: 5.045,
+                    imaginary: -5.67
+                }
+            ]);
+            allocateTest(viName, 'times', [
+                {
+                    seconds: '3564057536',
+                    fraction: '7811758927381448193'
+                }, {
+                    seconds: '3564057542',
+                    fraction: '16691056759750171331'
+                }
+            ]);
+
+            allocateTest(viName, 'fixedBooleans', [
+                [true, false],
+                [false, true]
+            ]);
+            allocateTest(viName, 'wave_Double', {
+                t0: {
+                    seconds: '300',
+                    fraction: '123'
+                },
+                dt: 8.8,
+                Y: [5.5, 6.6, 7.7, 8.8] // eslint-disable-line id-length
+            });
+            allocateTest(viName, 'nipath', {
+                type: 'ABSOLUTE',
+                components: ['C', 'Windows', 'System32']
+            });
+            allocateTest(viName, 'enum16numbers', 1);
+        });
+    });
+});

--- a/test-it/karma/publicapi/AllocateTypes.Test.js
+++ b/test-it/karma/publicapi/AllocateTypes.Test.js
@@ -89,7 +89,7 @@ describe('Vireo public API allows', function () {
                     dataRef: 0
                 };
 
-                expect(tryDeallocate(invalidValueRef)).toThrowError(/NullDataPointer/);
+                expect(tryDeallocate(invalidValueRef)).toThrowError(/InvalidDataPointer/);
             });
         });
     });


### PR DESCRIPTION
This PR is intended for review purposes only. I will create a new PR after addressing feedback gathered here and #471 is merged into master.

Exposing 2 functions that will allow JS to allocate variables based on a Type declared in the .via code and of course deallocate the memory.

The workflow goes as follow:
```javascript
var valueRef = vireo.eggShell.findValueRef(viName, path); // Look for a variable 
// valueRef contains a pointer to the type and the data for that variable
// allocateData only cares about the type.
var allocatedDataValueRef = vireo.eggShell.allocateData(valueRef); // This will allocate enough memory for that type
// Now any other functions to write and read can be used on the allocated space.
vireo.eggShell.writeJSON(allocatedDataValueRef, someValue);
vireo.eggShell.readJSON(allocatedDataValueRef);
// Once done with that data, e.g. after an event occurs, you can deallocate it.
vireo.eggShell.deallocateData(allocatedDataValueRef);
```

You can take a look to `AllocateTypes.Test.js` too.